### PR TITLE
:art: Indent test name and dim disabled tests for readability

### DIFF
--- a/include/GUnit/GTest.h
+++ b/include/GUnit/GTest.h
@@ -49,7 +49,7 @@ struct TestRun {
 
       if (disabled && !GTEST_FLAG(also_run_disabled_tests)) {
         if (colorize) {
-          std::cout << "\033[0;33m";
+          std::cout << "\33[0;33m\033[2m";
         }
         std::cout << "[ DISABLED ] ";
         if (colorize) {

--- a/include/GUnit/GTest.h
+++ b/include/GUnit/GTest.h
@@ -38,6 +38,8 @@ struct TestRun {
       return false;
     }
 
+    const auto indented_name = "    " + name;
+
     const auto result =
         line > test_line && FilterMatchesShould(name, should_param);
     if (result) {
@@ -53,7 +55,7 @@ struct TestRun {
         if (colorize) {
           std::cout << "\033[m";  // Resets the terminal to default.
         }
-        std::cout << name << std::endl;
+        std::cout << indented_name << std::endl;
         return false;
       }
 
@@ -64,7 +66,7 @@ struct TestRun {
       if (colorize) {
         std::cout << "\033[m";  // Resets the terminal to default.
       }
-      std::cout << name << std::endl;
+      std::cout << indented_name << std::endl;
       test_line = line;
       next = true;
     }


### PR DESCRIPTION
Problem:
- Quickly scanning the output is difficult.

Solution:
- Indent the test name to make it obvious that the `SHOULD`s are
  sub-tests.