### PR TITLE
:new: [GSteps] Allow hex numbers in as gherkin parameters

### DIFF
--- a/include/GUnit/Detail/StringUtils.h
+++ b/include/GUnit/Detail/StringUtils.h
@@ -60,12 +60,25 @@ inline std::vector<std::string> split(const std::string &str, char delimiter) {
   return result;
 }
 
-template <class T>
+template <class T, std::enable_if_t<!std::is_integral<T>::value, int> = 0>
 inline auto lexical_cast(const std::string &str) {
   std::remove_cv_t<std::remove_reference_t<T>> var{};
   std::istringstream iss{};
   iss.str(str);
   iss >> var;
+  return var;
+}
+
+template <class T, std::enable_if_t<std::is_integral<T>::value, int> = 0>
+inline auto lexical_cast(const std::string &str) {
+  std::remove_cv_t<std::remove_reference_t<T>> var{};
+  std::istringstream iss{};
+  iss.str(str);
+  if (str.size() > 2 and str[0] == '0' and str[1] == 'x') {
+    iss >> std::hex >> var;
+  } else {
+    iss >> var;
+  }
   return var;
 }
 

--- a/test/Detail/StringUtils.cpp
+++ b/test/Detail/StringUtils.cpp
@@ -71,6 +71,17 @@ TEST(StringUtils, ShouldReturnTrimmedString) {
   }
 }
 
+TEST(StringUtils, ShouldConvertToType) {
+  EXPECT_EQ("str", lexical_cast<std::string>("str"));
+
+  EXPECT_EQ(42, lexical_cast<int>("42"));
+  EXPECT_EQ(99u, lexical_cast<std::size_t>("99"));
+  EXPECT_EQ(0x30, lexical_cast<int>("0x30"));
+
+  EXPECT_EQ(true, lexical_cast<bool>("true"));
+  EXPECT_EQ(true, lexical_cast<bool>("1"));
+}
+
 }  // detail
 }  // v1
 }  // testing

--- a/test/GMake.cpp
+++ b/test/GMake.cpp
@@ -273,10 +273,10 @@ class di_complex_example {
       : csp(csp), sp(sp), cref(cref), ref(ref) {}
 
  private:
-  std::shared_ptr<interface> csp;
-  std::shared_ptr<interface2> sp;
-  const interface4& cref;
-  interface_dtor& ref;
+  [[maybe_unused]] std::shared_ptr<interface> csp;
+  [[maybe_unused]] std::shared_ptr<interface2> sp;
+  [[maybe_unused]] const interface4& cref;
+  [[maybe_unused]] interface_dtor& ref;
 };
 
 TEST(GMake, ShouldCreateComplexExampleUsingInjector) {


### PR DESCRIPTION
Problem:
- Only decimal numbers are allowed to be passed as gherkin parameters.

Solution:
- Add additional parsing for hex parameters.