### PR TITLE
:bug: Fix #29 - test/GSteps.cpp: -Werror build failure on ignored-qualifiers

### DIFF
--- a/test/GSteps.cpp
+++ b/test/GSteps.cpp
@@ -68,7 +68,7 @@ GTEST("Convertible") {
 
     const bool c = detail::Convertible<std::string>{"true"};
     EXPECT_TRUE(c);
-    EXPECT_FALSE(static_cast<const bool>(detail::Convertible<std::string>{"0"}));
+    EXPECT_FALSE(static_cast<bool>(detail::Convertible<std::string>{"0"}));
   }
 }
 


### PR DESCRIPTION
Problem:
- On gcc 8.3.0, test/GSteps.cpp:71 fails with "-Werror=ignored-qualifiers".

Solution:
- Static cast to "bool" instead of "const bool".