### PR TITLE
#1 add cucumber json formatter

### DIFF
--- a/include/GUnit/GSteps.h
+++ b/include/GUnit/GSteps.h
@@ -419,9 +419,6 @@ class Steps : public ::testing::EmptyTestEventListener {
       const auto pickles = compiler.compile(gherkin_document);
       const auto ast = nlohmann::json::parse(compiler.ast(gherkin_document));
 
-      std::ofstream output("ast.json");
-      output << std::setw(4) << ast <<std::endl;
-
       for (const auto& pickle : pickles) {
         const std::string feature_name = ast["document"]["feature"]["name"];
         const auto pickle_json = nlohmann::json::parse(pickle)["pickle"];

--- a/include/formatters/cucumberjson.hpp
+++ b/include/formatters/cucumberjson.hpp
@@ -1,0 +1,97 @@
+/*
+ * cucumberjson.hpp
+ *
+ *  Created on: Feb 18, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNITWRAPPER_FORMATTERS_CUCUMBERJSON_HPP_
+#define TESTS_GUNITWRAPPER_FORMATTERS_CUCUMBERJSON_HPP_
+
+#include <json.hpp>
+#include <gherkin.hpp>
+
+#include <fstream>
+#include <unordered_map>
+
+namespace Formatters {
+
+// reference of Json output comes from https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter
+class CucumberJson {
+public:
+	CucumberJson() = delete;
+	CucumberJson(std::string name_) : name(name_) {};
+	virtual ~CucumberJson() = default;
+
+	void generateReportFromFeatures(const std::unordered_map<std::string, std::shared_ptr<GherkinCpp::Feature>> features) {
+		for (const auto& feature : features) {
+			nlohmann::json curFeature;
+			curFeature["uri"] = feature.second->uri;
+			curFeature["keyword"] = feature.second->keyword;
+			curFeature["name"] = feature.second->name;
+			curFeature["line"] = feature.second->line;
+			curFeature["description"] = "";
+
+			std::unordered_map<std::string, std::shared_ptr<GherkinCpp::Tag>> featureTags = feature.second->getTags();
+
+			for (const auto& tag : featureTags) {
+				curFeature["tags"].push_back({
+						{"name", tag.second->name},
+						{"line", tag.second->line}
+				});
+			}
+
+			for (const auto& element : feature.second->getElements()) {
+				nlohmann::json curElement;
+				curElement["keyword"] = element.second->keyword;
+				curElement["name"] = element.second->name;
+				curElement["line"] = element.second->line;
+			    curElement["description"] = "";
+			    curElement["type"] = element.second->type;
+
+			    std::unordered_map<std::string, std::shared_ptr<GherkinCpp::Tag>> elementTags = element.second->getTags();
+				for (const auto& tag : elementTags) {
+					curElement["tags"].push_back({
+							{"name", tag.second->name},
+							{"line", tag.second->line}
+					});
+				}
+
+				for (const auto& step : element.second->getSteps()) {
+					nlohmann::json curStep;
+					curStep["keyword"] = step.second->keyword;
+					curStep["name"] = step.second->name;
+					curStep["line"] = step.second->line;
+					std::string resultStr = step.second->getResult()?"passed":"failed";
+					curStep["result"] = {
+							{"status", resultStr},
+							{"duration", 1}
+					};
+					curElement["steps"].push_back(curStep);
+				}
+
+				curFeature["elements"].push_back(curElement);
+			}
+
+			jsonReport.push_back(curFeature);
+		}
+	}
+
+	void publishReport() {
+		std::string fileName = name + ".json";
+		std::ofstream output(fileName);
+		output << std::setw(4) << jsonReport <<std::endl;
+	}
+
+private:
+
+private:
+	const std::string name;
+	nlohmann::json jsonReport{};
+};
+
+} //testing
+
+
+
+#endif /* TESTS_GUNITWRAPPER_FORMATTERS_CUCUMBERJSON_HPP_ */

--- a/include/formatters/features.hpp
+++ b/include/formatters/features.hpp
@@ -1,0 +1,67 @@
+/*
+ * features.hpp
+ *
+ *  Created on: Feb 18, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNITWRAPPER_FEATURES_HPP_
+#define TESTS_GUNITWRAPPER_FEATURES_HPP_
+
+#include <memory>
+#include <unordered_map>
+
+#include "gherkinCpp/feature.hpp"
+#include "cucumberjson.hpp"
+
+class Features {
+public:
+	virtual ~Features() {
+		publishReport();
+	}
+
+	static Features* getInstance() {
+		static Features instance;
+		return &instance;
+	}
+
+	void addFeature(std::shared_ptr<GherkinCpp::Feature> feature) {
+		if(feature == nullptr) return;
+		if(features.find(feature->name) != features.end()) {
+			std::cout << "Feature " << feature->name << " already exist." << std::endl;
+			return;
+		}
+		features[feature->name] = std::move(feature);
+	}
+
+	std::shared_ptr<GherkinCpp::Feature> getFeature(std::string featureName) {
+		std::unordered_map<std::string, std::shared_ptr<GherkinCpp::Feature>>::iterator it = features.find(featureName);
+		std::shared_ptr<GherkinCpp::Feature> retval{};
+
+		if(it != features.end()) {
+			retval = it->second;
+		}
+		return retval;
+	}
+
+	void addReport(std::string name) {
+		if(resultReport != nullptr) return;
+		resultReport = std::make_unique<Formatters::CucumberJson>(name);
+	}
+
+	void publishReport() {
+	 if(resultReport != nullptr){
+		  resultReport->generateReportFromFeatures(features);
+		  resultReport->publishReport();
+	  }
+	}
+private:
+	Features() = default;
+
+	std::unordered_map<std::string, std::shared_ptr<GherkinCpp::Feature>> features;
+	std::unique_ptr<Formatters::CucumberJson> resultReport;
+};
+
+
+
+#endif /* TESTS_GUNITWRAPPER_FEATURES_HPP_ */

--- a/include/formatters/gherkinCpp/background.hpp
+++ b/include/formatters/gherkinCpp/background.hpp
@@ -1,0 +1,25 @@
+/*
+ * background.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_BACKGROUND_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_BACKGROUND_HPP_
+
+#include "element.hpp"
+
+namespace GherkinCpp {
+
+class Background : public Element {
+public:
+	Background() = delete;
+	Background(int line_) : Element("Background", "Background", "background", line_) {};
+	virtual ~Background() = default;
+
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_BACKGROUND_HPP_ */

--- a/include/formatters/gherkinCpp/element.hpp
+++ b/include/formatters/gherkinCpp/element.hpp
@@ -1,0 +1,62 @@
+/*
+ * element.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_ELEMENT_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_ELEMENT_HPP_
+
+#include <unordered_map>
+
+#include "step.hpp"
+#include "genericinfo.hpp"
+#include "tag.hpp"
+
+namespace GherkinCpp {
+
+class Element : public GenericInfo {
+public:
+	Element() = delete;
+	Element(std::string type_, std::string keyword_, std::string name_, int line_) : GenericInfo(keyword_, name_, line_), type(type_) {};
+	virtual ~Element() = default;
+
+	void addStep(std::shared_ptr<Step> step) {
+		if(step == nullptr) return;
+
+		int stepMapKey = step->line;
+
+		if(steps.find(stepMapKey) != steps.end()) {
+			std::cout << "Scenario " << name << ": Step " << step->name << " in line " << step->line << " already exist." << std::endl;
+			return;
+		}
+
+		steps[stepMapKey] = std::move(step);
+	}
+
+	std::map<int, std::shared_ptr<Step>> getSteps() {
+		return steps;
+	}
+
+	std::shared_ptr<Step> getSpecificStep(int lineNum) {
+		std::map<int, std::shared_ptr<Step>>::iterator it = steps.find(lineNum);
+		std::shared_ptr<Step> retval{};
+
+		if(it != steps.end()) {
+			retval = it->second;
+		}
+		return retval;
+	}
+
+public:
+	const std::string type;
+
+private:
+	std::map<int, std::shared_ptr<Step>>  steps;
+	std::string description{};
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_ELEMENT_HPP_ */

--- a/include/formatters/gherkinCpp/feature.hpp
+++ b/include/formatters/gherkinCpp/feature.hpp
@@ -1,0 +1,60 @@
+/*
+ * feature.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_FEATURE_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_FEATURE_HPP_
+
+#include <unordered_map>
+#include <string>
+#include "genericinfo.hpp"
+#include "element.hpp"
+
+namespace GherkinCpp {
+
+class Feature : public GenericInfo {
+public:
+	Feature() = delete;
+	Feature(std::string name_, std::string uri_, int line_) : GenericInfo("Feature", name_, line_), uri(uri_){};
+	virtual ~Feature() = default;
+
+	void addElement(std::shared_ptr<Element> element) {
+		if(element == nullptr) return;
+
+		int elementKey = element->line;
+		if(elements.find(elementKey) != elements.end()) {
+			std::cout << "Feature " << name << ": Element " << element->name << " at line " << element->line << " already exist." << std::endl;
+			return;
+		}
+
+		elements[elementKey] = std::move(element);
+	}
+
+	std::unordered_map<int, std::shared_ptr<Element>>  getElements() {
+		return elements;
+	}
+
+	std::shared_ptr<Element> getSpecificElement(int lineNum) {
+		std::unordered_map<int, std::shared_ptr<Element>>::iterator it = elements.find(lineNum);
+		std::shared_ptr<Element> retval{};
+
+		if(it != elements.end()) {
+			retval = it->second;
+		}
+		return retval;
+	}
+
+public:
+	const std::string uri;
+
+private:
+	std::unordered_map<int, std::shared_ptr<Element>>  elements;
+	std::string description{};
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_FEATURE_HPP_ */

--- a/include/formatters/gherkinCpp/genericinfo.hpp
+++ b/include/formatters/gherkinCpp/genericinfo.hpp
@@ -1,0 +1,46 @@
+/*
+ * genericinfo.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_GENERICINFO_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_GENERICINFO_HPP_
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include "tag.hpp"
+
+namespace GherkinCpp {
+
+class GenericInfo {
+public:
+	GenericInfo() = delete;
+	GenericInfo(std::string keyword_, std::string name_, int line_) : name(name_), keyword(keyword_), line(line_) {};
+	virtual ~GenericInfo() = default;
+
+	std::unordered_map<std::string, std::shared_ptr<Tag>> getTags() {
+		return tags;
+	}
+
+	void addTag(std::shared_ptr<Tag> tag) {
+		if(tag == nullptr) return;
+		if(tags.find(tag->name) != tags.end()) {
+			std::cout << "Item " << name << ": Tag " << tag->name << " already exist." << std::endl;
+			return;
+		}
+
+		tags[tag->name] = std::move(tag);
+	}
+
+public:
+	const std::string name;
+	const std::string keyword;
+	const int line;
+	std::unordered_map<std::string, std::shared_ptr<Tag>> tags;
+};
+
+} // GherkinCpp
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_GENERICINFO_HPP_ */

--- a/include/formatters/gherkinCpp/scenario.hpp
+++ b/include/formatters/gherkinCpp/scenario.hpp
@@ -1,0 +1,25 @@
+/*
+ * scenario.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIO_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIO_HPP_
+
+#include "element.hpp"
+
+namespace GherkinCpp {
+
+class Scenario : public Element {
+public:
+	Scenario() = delete;
+	Scenario(std::string name_, int line_) : Element("scenario", "Scenario", name_, line_) {};
+	virtual ~Scenario() = default;
+
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIO_HPP_ */

--- a/include/formatters/gherkinCpp/scenariooutline.hpp
+++ b/include/formatters/gherkinCpp/scenariooutline.hpp
@@ -1,0 +1,25 @@
+/*
+ * scenario.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIOOUTLINE_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIOOUTLINE_HPP_
+
+#include "element.hpp"
+
+namespace GherkinCpp {
+
+class ScenarioOutline : public Element {
+public:
+	ScenarioOutline() = delete;
+	ScenarioOutline(std::string name_, int line_) : Element("scenario", "Scenario Outline", name_, line_) {};
+	virtual ~ScenarioOutline() = default;
+
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_SCENARIOOUTLINE_HPP_ */

--- a/include/formatters/gherkinCpp/step.hpp
+++ b/include/formatters/gherkinCpp/step.hpp
@@ -1,0 +1,35 @@
+/*
+ * step.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_STEP_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_STEP_HPP_
+
+#include <unordered_map>
+
+#include "genericinfo.hpp"
+
+namespace GherkinCpp {
+
+class Step : public GenericInfo{
+public:
+	Step() = delete;
+	Step(std::string keyword_, std::string name_, int line_) : GenericInfo(keyword_ , name_, line_) {};
+	virtual ~Step() = default;
+
+	void setResult(bool result_) {
+		result = result_;
+	}
+
+	bool getResult() { return result;}
+
+private:
+	bool result=true;
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_STEP_HPP_ */

--- a/include/formatters/gherkinCpp/tag.hpp
+++ b/include/formatters/gherkinCpp/tag.hpp
@@ -1,0 +1,29 @@
+/*
+ * tag.hpp
+ *
+ *  Created on: Feb 17, 2020
+ *      Author: rbauer
+ */
+
+#ifndef TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_TAG_HPP_
+#define TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_TAG_HPP_
+
+#include <string>
+#include <memory>
+
+namespace GherkinCpp {
+
+class Tag {
+public:
+	Tag() = delete;
+	Tag(std::string name_, int line_) : name(name_), line(line_) {};
+	virtual ~Tag() = default;
+
+public:
+	const std::string name;
+	const int line;
+};
+
+} // GherkinCpp
+
+#endif /* TESTS_GUNIT_LIBS_GHERKIN_CPP_INCLUDE_TAG_HPP_ */


### PR DESCRIPTION
Pull request would solve issue #34. When executing, instead of having only the variable `SCENARIO=<scenario_path>` the env variable `OUTPUT=json` be added as well, a file "guint_result.json" is created

The classes in formatters/gherkinCpp could be placed into the library gherkin-cpp. I just left it here for now, so it can compile and run all tests.

The part within the ParseAndRegister can also be moved to the gherkin-cpp library in the parser, but again, just left it here to be more easily readable for now and to be able to run all tests.