### PR TITLE
Add support for mocking functions with rvalue arguments.

### DIFF
--- a/include/GUnit/GMock.h
+++ b/include/GUnit/GMock.h
@@ -224,7 +224,7 @@ class GMock {
                                ? msgs.back().c_str()
                                : TName::c_str());
     }
-    return ptr->Invoke(args...);
+    return ptr->Invoke(std::forward<TArgs>(args)...);
   }
 
   template <class TName, class R, class... TArgs>
@@ -253,10 +253,10 @@ class GMock {
       auto *f =
           static_cast<FunctionMocker<R(TArgs...)> *>(fs[TName::c_str()].get());
       f->SetOwnerAndName(this, TName::c_str());
-      return f->Invoke(args...);
+      return f->Invoke(std::forward<TArgs>(args)...);
     }
 
-    return not_expected<TName, R, TArgs...>(args...);
+    return not_expected<TName, R, TArgs...>(std::forward<TArgs>(args)...);
   }
 
   template <class TName, class R, class B, class... TArgs>

--- a/test/GMock.cpp
+++ b/test/GMock.cpp
@@ -1093,3 +1093,21 @@ TEST(GMock, ShouldMockTemplates) {
 
   sut.bar();
 }
+
+struct interface_rvalue {
+  virtual ~interface_rvalue() = default;
+  virtual void f(int&&) = 0;
+};
+
+
+TEST(GMock, ShouldMockRvalues) {
+  using namespace testing;
+  StrictGMock<interface_rvalue> mock{};
+
+  EXPECT_CALL(mock, (f)(_)).WillOnce([](int&& value){
+    EXPECT_EQ(6, value);
+  });
+
+  mock.object().f(6);
+}
+


### PR DESCRIPTION
Added std::forward at specific places to move the arguments when
necessary.
This would solve issue #11.
Although all unit-tests run fine, I'm unsure if these changes would have any side effects. E.g. if there are cases where the argument value is still required after invoking the function.