### PR TITLE
Allow multiple parameterized tests for a single type.

### DIFF
--- a/include/GUnit/GTest.h
+++ b/include/GUnit/GTest.h
@@ -148,7 +148,7 @@ class GTestAutoRegister {
     UnitTest::GetInstance()
         ->parameterized_test_registry()
         .GetTestSuitePatternHolder<T>(
-            GetTypeName(detail::type<typename T::TEST_TYPE>{}),
+            (std::string{GetTypeName(detail::type<typename T::TEST_TYPE>{})} + T::TEST_NAME::c_str()).c_str(),
             {T::TEST_FILE, T::TEST_LINE})
         ->AddTestPattern(GetTypeName(detail::type<typename T::TEST_TYPE>{}),
                          GetTypeName(detail::type<typename T::TEST_TYPE>{}),
@@ -157,7 +157,7 @@ class GTestAutoRegister {
     UnitTest::GetInstance()
         ->parameterized_test_registry()
         .GetTestSuitePatternHolder<T>(
-            GetTypeName(detail::type<typename T::TEST_TYPE>{}),
+            (std::string{GetTypeName(detail::type<typename T::TEST_TYPE>{})} + T::TEST_NAME::c_str()).c_str(),
             {T::TEST_FILE, T::TEST_LINE})
         ->AddTestSuiteInstantiation(
             (std::string{IsDisabled(DISABLED)} + T::TEST_NAME::c_str()).c_str(),

--- a/test/GTest.cpp
+++ b/test/GTest.cpp
@@ -877,6 +877,10 @@ GTEST("ParamTest", "[Info]", testing::Values(1, 2, 3)) {
   }
 }
 
+GTEST("ParamTest", "[AdditionalInfo]", testing::Values(4, 5, 6)) {
+  SHOULD("be true") { EXPECT_TRUE(GetParam() >= 4 && GetParam() <= 6); }
+}
+
 GTEST(example, "[Values]", testing::Values(1, 2, 3)) {
   using namespace testing;
   ASSERT_TRUE(nullptr == sut.get());
@@ -890,6 +894,17 @@ GTEST(example, "[Values]", testing::Values(1, 2, 3)) {
 
     sut->update();
 
+    EXPECT_EQ(GetParam(), sut->get_data());
+  }
+}
+
+GTEST(example, "[AdditionalValues]", testing::Values(4, 5, 6)) {
+  using namespace testing;
+  ASSERT_TRUE(nullptr == sut.get());
+  EXPECT_EQ(0u, mocks.size());
+
+  SHOULD("override sut with given param") {
+    std::tie(sut, mocks) = make<SUT, StrictGMock>(GetParam());
     EXPECT_EQ(GetParam(), sut->get_data());
   }
 }


### PR DESCRIPTION
This is very helpful if tests for parts of a class should be split up, e.g. for different functions, and require different types of parameters.
The idea is to not only use the type name as suite name but also add the test name.

I'm not sure if something will be broken with it. For some reason also GTest only uses the suite name for GetTestSuitePatternHolder(). However with GTest usually different fixture classes are created. With GUnit only the class to be tested needs to be specified.