### PR TITLE
:bug: Namespace ambiguity with detail

### DIFF
--- a/include/GUnit/GTest-Lite.h
+++ b/include/GUnit/GTest-Lite.h
@@ -39,10 +39,10 @@ struct test<false, Chars...> {
 
 template <class T, T... Chars>
 constexpr auto operator""_test() {
-  return detail::test<true, Chars...>{};
+  return ::detail::test<true, Chars...>{};
 }
 
 template <class T, T... Chars>
 constexpr auto operator""_test_disabled() {
-  return detail::test<false, Chars...>{};
+  return ::detail::test<false, Chars...>{};
 }


### PR DESCRIPTION
Problem:
- For `_test` and `_test_disabled` UDLs, their reference to `detail`
  namespace may be ambiguous. This would be the case if including this
  header file and also having a `using namespace` directive for a
  namespace which it itself has a `detail` namespace.

Solution:
- Avoid namespace ambiguity by prefixing with `::` when referring to
 `detail` namespace.