### PR TITLE
:new: [GAssert] EXPECT/ASSERT without special cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ test(example/GTest-Lite SCENARIO=)
 test(example/GSteps SCENARIO=${CMAKE_CURRENT_SOURCE_DIR}/example/GSteps.feature)
 
 include_directories(test)
+test(test/GAssert SCENARIO=)
 test(test/GMake SCENARIO=)
 test(test/GMock SCENARIO=)
 test(test/GSteps SCENARIO=)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### Motivation Examples
 
-> #### No more base classes and labels as identifiers - [GUnit.GTest](docs/GTest.md) / [GUnit.GTest-Lite](docs/GTest-Lite.md)
+> #### No more base classes, labels as identifiers and special assertions - [GUnit.GTest](docs/GTest.md) / [GUnit.GTest-Lite](docs/GTest-Lite.md)
   ```cpp
                  Google.Test                        |                     GUnit.GTest
   --------------------------------------------------+------------------------------------------------------
@@ -38,15 +38,15 @@
    }                                                |   // SetUp
                                                     |
    void TearDown() override { }                     |   SHOULD("return sum of 2 numbers") {
-                                                    |     EXPECT_EQ(5, calc->add(4, 1));
+                                                    |     EXPECT(5 == calc->add(4, 1));
    std::unique_ptr<Calc> calc;                      |   }
   };                                                |
                                                     |   SHOULD("throw if division by 0") {
-  TEST_F(CalcTest, ShouldReturnSumOf2Numbers) {  |     EXPECT_ANY_THROW(calc->div(42, 0));
+  TEST_F(CalcTest, ShouldReturnSumOf2Numbers) {     |     EXPECT_ANY_THROW(calc->div(42, 0));
     EXPECT_EQ(5, calc->add(4, 1));                  |   }
   }                                                 |
                                                     |   // TearDown
-  TEST_F(CalcTest, ShouldThrowIfDivisionBy0) {   | }
+  TEST_F(CalcTest, ShouldThrowIfDivisionBy0) {      | }
     EXPECT_ANY_THROW(calc->div(42, 0));             |
   }                                                 |
   ```

--- a/include/GUnit/GAssert.h
+++ b/include/GUnit/GAssert.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <string>
+#include "GUnit/Detail/StringUtils.h"
+
+namespace testing {
+inline namespace v1 {
+namespace detail {
+
+struct info {
+  const char* file{};
+  unsigned long line{};
+  std::string expr{};
+  TestPartResult::Type failure{};
+};
+
+template<class TLhs, class TRhs, AssertionResult (*Comp)(const char*, const char*, TLhs, TRhs)>
+class msg : public decltype(Message()) {
+ public:
+  msg(const info& info, const std::string& comp, TLhs lhs, TRhs rhs) : info_{info}, comp_{comp}, lhs_{lhs}, rhs_{rhs} { }
+ ~msg() {
+    const auto begin = info_.expr.find(comp_);
+    auto lhs_expr = info_.expr.substr(0, begin);
+    trim(lhs_expr);
+    auto rhs_expr = info_.expr.substr(begin+std::size(comp_));
+    trim(rhs_expr);
+    const AssertionResult gtest_ar = (Comp(lhs_expr.c_str(), rhs_expr.c_str(), lhs_, rhs_));
+    if (!gtest_ar) {
+      internal::AssertHelper(info_.failure, info_.file, info_.line, gtest_ar.failure_message()) = *this;
+    }
+  }
+
+ private:
+  info info_{};
+  std::string comp_{};
+  TLhs lhs_;
+  TRhs rhs_;
+};
+
+class op {
+  template<class TLhs>
+  class comp {
+   public:
+    explicit comp(const info& info, const TLhs& lhs)
+      : info_{info}, lhs_{lhs} {}
+
+    template<class TRhs, std::enable_if_t<std::is_floating_point<TLhs>::value || std::is_floating_point<TRhs>::value, int> = 0>
+    auto operator==(const TRhs& rhs) const {
+      return msg<TLhs, TRhs, internal::CmpHelperFloatingPointEQ<TLhs>>{info_, "==", lhs_, rhs};
+    }
+
+    template<class TRhs, std::enable_if_t<!std::is_floating_point<TLhs>::value && !std::is_floating_point<TRhs>::value, int> = 0>
+    auto operator==(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperEQ>{info_, "==", lhs_, rhs};
+    }
+
+    template<class TRhs>
+    auto operator!=(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperNE>{info_, "!=", lhs_, rhs};
+    }
+
+    template<class TRhs>
+    auto operator>(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperGT>{info_, ">", lhs_, rhs};
+    }
+
+    template<class TRhs>
+    auto operator>=(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperGE>{info_, ">=", lhs_, rhs};
+    }
+
+    template<class TRhs>
+    auto operator<=(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperLE>{info_, "<=", lhs_, rhs};
+    }
+
+    template<class TRhs>
+    auto operator<(const TRhs& rhs) const {
+      return msg<const TLhs&, const TRhs&, internal::CmpHelperLT>{info_, "<", lhs_, rhs};
+    }
+
+   private:
+    info info_{};
+    TLhs lhs_{};
+  };
+
+ public:
+  explicit op(const info& info)
+    : info_{info} {}
+
+  template<class TLhs> comp<TLhs> operator%(const TLhs& lhs) const { return comp<TLhs>{info_, lhs}; }
+
+ private:
+  info info_{};
+};
+} // namespace detail
+} // namespace v1
+} // namespace testing
+
+#define EXPECT(...) (::testing::detail::op{::testing::detail::info{__FILE__,  __LINE__, #__VA_ARGS__, ::testing::TestPartResult::kNonFatalFailure}} % __VA_ARGS__)
+#define ASSERT(...) (::testing::detail::op{::testing::detail::info{__FILE__,  __LINE__, #__VA_ARGS__, ::testing::TestPartResult::kFatalFailure}} % __VA_ARGS__)

--- a/test/GAssert.cpp
+++ b/test/GAssert.cpp
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016-2017 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <gtest/gtest.h>
+#include "GUnit/GAssert.h"
+
+TEST(GAssert, ShouldSupportExpect) {
+  auto i = 42;
+
+  EXPECT(i == 42);
+  EXPECT(42 == i);
+  EXPECT(42 == i);
+
+  EXPECT(i != 0);
+  EXPECT(0 != i);
+
+  EXPECT(i > 0) << "message";
+  EXPECT(i >= 0) << "message";
+  EXPECT(i <= 42) << "message";
+  EXPECT(i < 100) << "message";
+
+  EXPECT(42.0 == 42.);
+}
+
+TEST(GAssert, ShouldSupportASSERT) {
+  auto i = 42;
+
+  ASSERT(i == 42);
+  ASSERT(42 == i);
+  ASSERT(42 == i);
+
+  ASSERT(i != 0);
+  ASSERT(0 != i);
+
+  ASSERT(i > 0) << "message";
+  ASSERT(i >= 0) << "message";
+  ASSERT(i <= 42) << "message";
+  ASSERT(i < 100) << "message";
+
+  ASSERT(42.0 == 42.);
+}


### PR DESCRIPTION
Problem:
- EXPECT_EQ/ASSERT_EQ and friends aren't very easy to use and there are
  different overloads based on types.

Solution:
- Introduce EXPECT(...)/ASSERT(...) which uses natural way of expressing logic.