### PR TITLE
:new: [example] GAssert example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
   endfunction()
 endif()
 
+test(example/GAssert SCENARIO=)
 test(example/GMock SCENARIO=)
 test(example/GTest SCENARIO=)
 test(example/GTest-Lite SCENARIO=)

--- a/example/GAssert.cpp
+++ b/example/GAssert.cpp
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2016-2017 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include "GUnit/GAssert.h"
+
+int main() {
+  EXPECT(true);
+
+  const auto i = 42;
+  EXPECT(42 == i);
+
+  ASSERT(42.0 == 42.);
+}

--- a/include/GUnit/GSteps.h
+++ b/include/GUnit/GSteps.h
@@ -388,7 +388,7 @@ class Steps : public ::testing::EmptyTestEventListener {
     return Step<-1, true>{*this, {"Then", File::c_str(), line}, pattern};
   }
 
-  // clang-format off
+// clang-format off
   #if defined(__clang__)
   #pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
   #endif


### PR DESCRIPTION
Problem:
- There are no examples for ASSERT/EXPECT.

Solution:
- Add GAssert examples.