### PR TITLE
:bug: [EXPECT/ASSERT] Fix support for boolean expression

### DIFF
--- a/example/GAssert.cpp
+++ b/example/GAssert.cpp
@@ -8,8 +8,13 @@
 #include "GUnit/GAssert.h"
 
 int main() {
+  const auto b = true;
   const auto i = 42;
+
+  EXPECT(true);
+  EXPECT(b);
   EXPECT(42 == i);
   EXPECT(42 >= 0) << "message";
+
   ASSERT(42.0 == 42.);
 }

--- a/include/GUnit/GSteps.h
+++ b/include/GUnit/GSteps.h
@@ -388,7 +388,7 @@ class Steps : public ::testing::EmptyTestEventListener {
     return Step<-1, true>{*this, {"Then", File::c_str(), line}, pattern};
   }
 
-  // clang-format off
+// clang-format off
   #if defined(__clang__)
   #pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
   #endif

--- a/test/GAssert.cpp
+++ b/test/GAssert.cpp
@@ -10,6 +10,11 @@
 
 TEST(GAssert, ShouldSupportExpect) {
   auto i = 42;
+  const auto b = true;
+
+  EXPECT(true);
+  EXPECT(!false) << "message";
+  EXPECT(b);
 
   EXPECT(i == 42);
   EXPECT(42 == i);
@@ -27,7 +32,9 @@ TEST(GAssert, ShouldSupportExpect) {
 }
 
 TEST(GAssert, ShouldSupportASSERT) {
-  auto i = 42;
+  const auto i = 42;
+
+  ASSERT(true);
 
   ASSERT(i == 42);
   ASSERT(42 == i);


### PR DESCRIPTION
Problem:
- EXPECT/ASSERT doesn't work properly with single boolean expression
  which is not followed by an operator.

Solution:
- Add logic in the comp destructor to recognise this use case and fire if needed.