### PR TITLE
Request to set CXX-14 instead of CXX-17 as a minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ option(ENABLE_COVERAGE "Run coverage." OFF)
 add_custom_target(style)
 add_custom_command(TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark ${CMAKE_CURRENT_LIST_DIR}/example ${CMAKE_CURRENT_LIST_DIR}/include ${CMAKE_CURRENT_LIST_DIR}/test -iname "*.h" -or -iname "*.cpp" | xargs clang-format -i)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
+set(CMAKE_CXX_STANDARD 14)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/include/GUnit/GAssert.h
+++ b/include/GUnit/GAssert.h
@@ -10,7 +10,6 @@
 #include <gtest/gtest.h>
 
 #include <string>
-
 #include "GUnit/Detail/StringUtils.h"
 
 namespace testing {
@@ -34,7 +33,7 @@ class msg : public decltype(Message()) {
     const auto begin = info_.expr.find(comp_);
     auto lhs_expr = info_.expr.substr(0, begin);
     trim(lhs_expr);
-    auto rhs_expr = info_.expr.substr(begin + std::size(comp_));
+    auto rhs_expr = info_.expr.substr(begin + comp_.size());
     trim(rhs_expr);
     const AssertionResult gtest_ar =
         (Comp(lhs_expr.c_str(), rhs_expr.c_str(), lhs_, rhs_));


### PR DESCRIPTION
In our project we still are on CXX 14 and if GUnit would force CXX-17 we wouldn't be able to use it, except with a fork we would have to maintain on our own.

Could you please consider using CXX 14 as a default for the project?

We are using GUnit with the CXX 14 hacked into, and it works pretty well. So the only change was this most recent patch introducing std::size() from CXX 17.