### PR TITLE
Added gunit INTERFACE target, integrated gherkin-cpp via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,26 +31,24 @@ enable_testing()
 
 add_subdirectory(libs/googletest)
 
-include_directories(include)
-include_directories(SYSTEM
-  ${gtest_SOURCE_DIR}/include
+add_library(gunit INTERFACE)
+target_include_directories(gunit INTERFACE include)
+target_include_directories(gunit
+  INTERFACE ${gtest_SOURCE_DIR}/include
   ${gmock_SOURCE_DIR}/include
   libs/json/single_include/nlohmann
-  libs/gherkin-cpp/include
 )
 
-link_directories(${CMAKE_CURRENT_LIST_DIR}/libs/gherkin-cpp)
+target_link_libraries(gunit
+  INTERFACE gtest_main
+  INTERFACE gmock_main
+  INTERFACE gherkin-cpp
+)
 
 set(BUILD_GMOCK)
 set(BUILD_GTEST)
 
-add_custom_command(
-  OUTPUT libgherkin-cpp-static
-  COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/libs/gherkin-cpp && make lib-static
-)
-add_custom_target(
-  gherkin_cpp-static ALL DEPENDS libgherkin-cpp-static
-)
+add_subdirectory(libs/gherkin-cpp)
 
 find_program(MEMORYCHECK_COMMAND valgrind)
 if (ENABLE_MEMCHECK AND MEMORYCHECK_COMMAND)
@@ -58,18 +56,16 @@ if (ENABLE_MEMCHECK AND MEMORYCHECK_COMMAND)
     string(REPLACE "/" "_" out ${name})
     add_executable(${out} ${CMAKE_CURRENT_LIST_DIR}/${name}.cpp)
     add_test(${out} ${MEMORYCHECK_COMMAND} --leak-check=full --error-exitcode=1 ./${out})
-    add_dependencies(${out} gherkin_cpp-static)
-    target_link_libraries(${out} gtest_main gmock_main gherkin-cpp)
-    add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out})
+    target_link_libraries(${out} gunit)
+    add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out} --gtest_color=yes USES_TERMINAL)
   endfunction()
 else()
   function(test name scenario)
     string(REPLACE "/" "_" out ${name})
     add_executable(${out} ${CMAKE_CURRENT_LIST_DIR}/${name}.cpp)
     add_test(${out} ./${out})
-    add_dependencies(${out} gherkin_cpp-static)
-    target_link_libraries(${out} gtest_main gmock_main gherkin-cpp)
-    add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out})
+    target_link_libraries(${out} gunit)
+    add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out} --gtest_color=yes USES_TERMINAL)
   endfunction()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -223,22 +223,30 @@
 
 ---
 
-* [**Optional**] For [gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin) support
-    * Compile `gherkin-cpp`
-    ```sh
-    $cd libs/gherkin-cpp && make lib
-    $ls libs/gherkin-cpp
-      libgherkin-cpp.a
-      libgherkin-cpp.so
-    ```
-    * Add include paths
-        * `-I GUnit/gherkin-cpp/include`
-        * `-I GUnit/json/src`
-    * Link with `libgherkin-cpp.{a, so}`
-        * `-L libgherkin-cpp`
-    * Write some feature tests...
-    * Compile and Run!
-
+* [gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin) support using CMake
+    * `gherkin-cpp` using add_subdirectory
+        ```sh
+          # using add_subdirectory from the top-level CMakeLists.txt file:
+          add_subdirectory(gunit)
+        ```
+        ```sh
+          # src/CMakeLists.txt contains either this:
+          add_executable(myprogram)
+          target_link_libraries(myprogram gunit)
+          ...
+          # or you could have also been more explicit, then you would write this:
+          target_link_libraries(myprogram gtest gtest_main)
+        ```
+    * `gherkin-cpp` using a ExternalProject_Add(gunit ...)
+        Note: This sections needs updates, when writing the gherkin-cpp CMake integration I used add_subdirectory:
+        * Add include paths
+            * `-I GUnit_install_dir/include`
+        * Link with `libgherkin-cpp.{a, so}` Note: I wasn't able to nest the fmem/gherkin into libghekin-cpp, so two more libs to add: fmem/gherkin!   
+            * `-L gherkin-cpp`
+            * `-L fmem`
+            * `-L gherkin`
+        * Write some feature tests...
+        * Compile and Run!
 ---
 
 * To run GUnit tests/benchmarks
@@ -254,7 +262,8 @@
   * `GSteps`
     * [libs/json](https://github.com/nlohmann/json)
     * [libs/gherkin-cpp](https://github.com/c-libs/gherkin-cpp)
-
+      * [libs/gherkin-cpp/libs/fmem](https://github.com/c-libs/fmem.git)
+      * [libs/gherkin-cpp/libs/gherkin-c](https://github.com/c-libs/gherkin-c.git)
 ### Tested compilers
   * [Linux - GCC-5+](https://travis-ci.org/cpp-testing/GUnit)
   * [Linux - Clang-3.7+](https://travis-ci.org/cpp-testing/GUnit)


### PR DESCRIPTION
This PR is using the gherkin-cpp with the new CMake integration!
It was developed using add_subdirectory but the installation with a STAGING_DIR and ExternalProject_Add is also supported but not as well documented.

This build works with make and ninja!