### PR TITLE
Add MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 #
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(GUnit CXX)
 
 set(MASTER_PROJECT OFF)
@@ -24,11 +24,24 @@ add_custom_command(TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark
 
 set(CMAKE_CXX_STANDARD 14)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+if(NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+endif()
+
+if(MSVC)
+  add_compile_options(/EHsc)
+  # Statically link libraries
+  # See https://gitlab.kitware.com/cmake/cmake/-/issues/18390
+  add_compile_options(
+          $<$<CONFIG:>:/MT>
+          $<$<CONFIG:Debug>:/MTd>
+          $<$<CONFIG:Release>:/MT>
+  )
+endif(MSVC)
 
 if(ENABLE_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")

--- a/include/GUnit/Detail/ProgUtils.h
+++ b/include/GUnit/Detail/ProgUtils.h
@@ -7,7 +7,9 @@
 //
 #pragma once
 
+#if !defined(_WIN32) && !defined(_WIN64)
 #include <cxxabi.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -35,11 +37,15 @@ inline namespace v1 {
 namespace detail {
 
 inline std::string demangle(const std::string &mangled) {
+#if !defined(_WIN32) && !defined(_WIN64)
   const auto demangled = abi::__cxa_demangle(mangled.c_str(), 0, 0, 0);
   if (demangled) {
     std::shared_ptr<char> free{demangled, std::free};
     return demangled;
   }
+#else
+  return mangled;
+#endif
   return {};
 }
 

--- a/include/GUnit/GSteps.h
+++ b/include/GUnit/GSteps.h
@@ -175,7 +175,7 @@ inline std::pair<bool, std::string> make_tags(const nlohmann::json& tags) {
   for (const auto& tag : tags) {
     std::string tag_name = tag["name"];
     if (i++) {
-      result += ",";
+      result += ";";
     }
     if (tag_name == "@disabled") {
       disabled = true;


### PR DESCRIPTION
I had to change the delimiter of the tags in the testname for the GStesps. Somehow the comma was not working in Windows, and only one test would be executed within a feature file.