### PR TITLE
Support googletest 1.12.1

### DIFF
--- a/include/GUnit/Detail/TypeTraits.h
+++ b/include/GUnit/Detail/TypeTraits.h
@@ -154,20 +154,22 @@ auto get_type_name_impl(const char *ptr, std::index_sequence<Ns...>) {
   return str;
 }
 
+
+#if defined(__clang__)
 constexpr bool const_strncmp(const char* a, const char*b, uint8_t n)
 {
-    bool retval = 1;
-
+    bool retval = false;
     for(uint8_t i = 0; i<n; i++)
     {
         if(a[i] != b[i])
         {
-            retval = 0;
+            retval = true;
             break;
         }
     }
     return retval;
 }
+#endif
 
 template <class T>
 const char *get_type_name() {
@@ -175,7 +177,7 @@ const char *get_type_name() {
 #if defined(__clang__)
     constexpr char opt1[] = "const char *testing::v1::detail::get_type_name() [T = ";
     constexpr char opt2[] = "const char *testing::detail::get_type_name() [T = ";
-    constexpr uint16_t offset = const_strncmp(__PRETTY_FUNCTION__, opt1, sizeof(opt1)-1)? sizeof(opt1)-1 : sizeof(opt2)-1;
+    constexpr uint16_t offset = const_strncmp(__PRETTY_FUNCTION__, opt1, sizeof(opt1)-1)? sizeof(opt2)-1 : sizeof(opt1)-1;
 #elif defined(__GNUC__)
     constexpr uint16_t offset = sizeof("const char* testing::v1::detail::get_type_name() [with T = ") - 1;
 #endif

--- a/include/GUnit/Detail/TypeTraits.h
+++ b/include/GUnit/Detail/TypeTraits.h
@@ -154,17 +154,36 @@ auto get_type_name_impl(const char *ptr, std::index_sequence<Ns...>) {
   return str;
 }
 
+constexpr bool const_strncmp(const char* a, const char*b, uint8_t n)
+{
+    bool retval = 1;
+
+    for(uint8_t i = 0; i<n; i++)
+    {
+        if(a[i] != b[i])
+        {
+            retval = 0;
+            break;
+        }
+    }
+    return retval;
+}
+
 template <class T>
 const char *get_type_name() {
+
 #if defined(__clang__)
-  return get_type_name_impl<T, 54>(
-      __PRETTY_FUNCTION__,
-      std::make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 54 - 2>{});
+    constexpr char opt1[] = "const char *testing::v1::detail::get_type_name() [T = ";
+    constexpr char opt2[] = "const char *testing::detail::get_type_name() [T = ";
+    constexpr uint16_t offset = const_strncmp(__PRETTY_FUNCTION__, opt1, sizeof(opt1)-1)? sizeof(opt1)-1 : sizeof(opt2)-1;
 #elif defined(__GNUC__)
-  return get_type_name_impl<T, 59>(
-      __PRETTY_FUNCTION__,
-      std::make_index_sequence<sizeof(__PRETTY_FUNCTION__) - 59 - 2>{});
+    constexpr uint16_t offset = sizeof("const char* testing::v1::detail::get_type_name() [with T = ") - 1;
 #endif
+    constexpr auto length = sizeof(__PRETTY_FUNCTION__) - offset - 2; // " ]" in the end has length 2
+
+    return get_type_name_impl<T, offset>(
+        __PRETTY_FUNCTION__,
+        std::make_index_sequence<length>{});
 }
 
 }  // namespace detail

--- a/include/GUnit/GMock.h
+++ b/include/GUnit/GMock.h
@@ -563,8 +563,8 @@ auto object(TMock *mock) {
 #define __GMOCK_OVERLOAD_CALL(...) __GUNIT_SIZE(__VA_ARGS__) __GUNIT_IGNORE
 #define __GMOCK_OVERLOAD_CAST_IMPL_1(obj, call)
 #define __GMOCK_OVERLOAD_CAST_IMPL_2(obj, call)                          \
-  (::testing::detail::function_type_t<std::decay_t<decltype(obj)>::type, \
-                                      __GMOCK_FUNCTION call>)
+  static_cast<::testing::detail::function_type_t<std::decay_t<decltype(obj)>::type, \
+                                      __GMOCK_FUNCTION call>>
 #define __GMOCK_INTERNAL(...)               \
   __GUNIT_IF(__GUNIT_IS_EMPTY(__VA_ARGS__)) \
   (__GUNIT_IGNORE, __GUNIT_COMMA)() __VA_ARGS__
@@ -578,8 +578,8 @@ auto object(TMock *mock) {
 #define __GMOCK_EXPECT_CALL_1(obj, qcall, call)                              \
   ((obj).template gmock_call<__GMOCK_QNAME call>(                            \
        __GUNIT_CAT(__GMOCK_OVERLOAD_CAST_IMPL_, __GMOCK_OVERLOAD_CALL call)( \
-           obj, call) &                                                      \
-       std::decay_t<decltype(obj)>::type::__GMOCK_NAME call __GMOCK_CALL     \
+           obj, call)( &                                                     \
+       std::decay_t<decltype(obj)>::type::__GMOCK_NAME call) __GMOCK_CALL    \
            call))                                                            \
       .InternalExpectedAt(__FILE__, __LINE__, #obj, #qcall)
 
@@ -608,8 +608,8 @@ auto object(TMock *mock) {
 #define __GMOCK_ON_CALL_1(obj, qcall, call)                                  \
   ((obj).template gmock_call<__GMOCK_QNAME call>(                            \
        __GUNIT_CAT(__GMOCK_OVERLOAD_CAST_IMPL_, __GMOCK_OVERLOAD_CALL call)( \
-           obj, call) &                                                      \
-       std::decay_t<decltype(obj)>::type::__GMOCK_NAME call __GMOCK_CALL     \
+           obj, call)( &                                                     \
+       std::decay_t<decltype(obj)>::type::__GMOCK_NAME call) __GMOCK_CALL    \
            call))                                                            \
       .InternalDefaultActionSetAt(__FILE__, __LINE__, #obj, #qcall)
 

--- a/include/GUnit/GMock.h
+++ b/include/GUnit/GMock.h
@@ -96,16 +96,17 @@ struct virtual_offset {
 template <class R, class B, class... TArgs>
 inline auto offset(R (B::*f)(TArgs...) const) {
   auto ptr = reinterpret_cast<std::size_t (virtual_offset::*)(int)>(f);
-  return (virtual_offset{}.*ptr)(0);
+  return (virtual_offset{}.*ptr)(0); // NOLINT
 }
 
 template <class R, class B, class... TArgs>
 inline auto offset(R (B::*f)(TArgs...)) {
   auto ptr = reinterpret_cast<std::size_t (virtual_offset::*)(int)>(f);
-  return (virtual_offset{}.*ptr)(0);
+  return (virtual_offset{}.*ptr)(0); // NOLINT
 }
 
 template <class T>
+__attribute__((no_sanitize("undefined")))
 inline auto dtor_offset() {
   virtual_offset offset;
   union_cast<T *>(&offset)->~T();

--- a/include/GUnit/GMock.h
+++ b/include/GUnit/GMock.h
@@ -192,7 +192,7 @@ UnregisterCallReactionType UnregisterCallReaction();
 template struct GetAccessUnregisterCallReactionType<
     &Mock::GetReactionOnUninterestingCalls>;
 
-using AllowUninterestingCallsType = void (*)(const void *);
+using AllowUninterestingCallsType = void (*)(uintptr_t);
 template <AllowUninterestingCallsType Ptr>
 struct GetAccessAllowUninterestingCallsType {
   friend AllowUninterestingCallsType AllowUninterestingCalls() { return Ptr; }
@@ -201,7 +201,7 @@ AllowUninterestingCallsType AllowUninterestingCalls();
 template struct GetAccessAllowUninterestingCallsType<
     &Mock::AllowUninterestingCalls>;
 
-using FailUninterestingCallsType = void (*)(const void *);
+using FailUninterestingCallsType = void (*)(uintptr_t);
 template <FailUninterestingCallsType Ptr>
 struct GetAccessFailUninterestingCallsType {
   friend FailUninterestingCallsType FailUninterestingCalls() { return Ptr; }
@@ -367,7 +367,7 @@ class NiceMock<GMock<T>> final : public GMock<T> {
   NiceMock(const NiceMock &) = delete;
   NiceMock() {
     detail::AllowUninterestingCalls()(
-        internal::ImplicitCast_<GMock<T> *>(this));
+        reinterpret_cast<uintptr_t>(this));
   }
   ~NiceMock() {
     detail::UnregisterCallReaction()(internal::ImplicitCast_<GMock<T> *>(this));
@@ -379,12 +379,12 @@ class StrictMock<GMock<T>> final : public GMock<T> {
  public:
   template <class... Ts>
   StrictMock(Ts &&... ts) : GMock<T>{std::forward<Ts>(ts)...} {
-    detail::FailUninterestingCalls()(internal::ImplicitCast_<GMock<T> *>(this));
+    detail::FailUninterestingCalls()(reinterpret_cast<uintptr_t>(this));
   }
   StrictMock(StrictMock &&) = default;
   StrictMock(const StrictMock &) = delete;
   StrictMock() {
-    detail::FailUninterestingCalls()(internal::ImplicitCast_<GMock<T> *>(this));
+    detail::FailUninterestingCalls()(reinterpret_cast<uintptr_t>(this));
   }
   ~StrictMock() {
     detail::UnregisterCallReaction()(internal::ImplicitCast_<GMock<T> *>(this));

--- a/include/GUnit/GTest.h
+++ b/include/GUnit/GTest.h
@@ -286,9 +286,9 @@ class GTest : public detail::GTest<T, TParamType> {};
                &__GUNIT_CAT(GTEST_GENERATE_NAMES, __LINE__))
 
 #define GTEST(...) \
-  __GUNIT_CAT(__GTEST_IMPL_, __GUNIT_SIZE(__VA_ARGS__))(false, __VA_ARGS__)
+  __GUNIT_CAT(__GTEST_IMPL_, __GUNIT_SIZE(__VA_ARGS__))(false, __VA_ARGS__) // NOLINT
 #define DISABLED_GTEST(...) \
-  __GUNIT_CAT(__GTEST_IMPL_, __GUNIT_SIZE(__VA_ARGS__))(true, __VA_ARGS__)
+  __GUNIT_CAT(__GTEST_IMPL_, __GUNIT_SIZE(__VA_ARGS__))(true, __VA_ARGS__) // NOLINT
 
 #define SHOULD(NAME) if (tr_gtest.run("SHOULD", NAME, __LINE__))
 #define DISABLED_SHOULD(NAME) if (tr_gtest.run("SHOULD", NAME, __LINE__, true))

--- a/test/Detail/TypeTraits.cpp
+++ b/test/Detail/TypeTraits.cpp
@@ -8,6 +8,8 @@
 #include "GUnit/Detail/TypeTraits.h"
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 struct a {};
 
 namespace testing {
@@ -136,7 +138,13 @@ TEST(TypeTraits, ShouldGetTypeName) {
   EXPECT_STREQ("int", get_type_name<int>());
   EXPECT_STREQ("const double", get_type_name<const double>());
   EXPECT_STREQ("a", get_type_name<a>());
+#if defined(__clang__)
+  std::vector<std::string> expected = {"testing::v1::detail::n","testing::detail::n"}; // get_type_name result may not contain v1::
+  EXPECT_TRUE( std::find(expected.begin(), expected.end(), get_type_name<n>()) != expected.end() );
+#elif defined(__GNUC__)
   EXPECT_STREQ("testing::v1::detail::n", get_type_name<n>());
+#endif
+//  EXPECT_STREQ("a", "b");
 }
 }  // detail
 }  // v1


### PR DESCRIPTION
In this PR I have updated to googletest 1.12.1

Additionally I have fixed some smaller findings, especially regarding clang:
- added: `// NOLINT` to ignore findings for 
    -clang-analyzer-core.NonNullParamChecker
    -clang-analyzer-core.CallAndMessage
- fixed: unit test using `get_type_name()` may not contain inline namespace `v1::`
- fixed: using `static_cast` to avoid -Wold-style-cast compiler warning