### PR TITLE
Added environment variables to test registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,10 @@ if (ENABLE_MEMCHECK AND MEMORYCHECK_COMMAND)
     string(REPLACE "/" "_" out ${name})
     add_executable(${out} ${CMAKE_CURRENT_LIST_DIR}/${name}.cpp)
     add_test(${out} ${MEMORYCHECK_COMMAND} --leak-check=full --error-exitcode=1 ./${out})
+    set_tests_properties(${out}
+    PROPERTIES
+    ENVIRONMENT ${scenario}
+    )
     target_link_libraries(${out} gunit)
     add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out} --gtest_color=yes USES_TERMINAL)
   endfunction()
@@ -85,6 +89,10 @@ else()
     string(REPLACE "/" "_" out ${name})
     add_executable(${out} ${CMAKE_CURRENT_LIST_DIR}/${name}.cpp)
     add_test(${out} ./${out})
+    set_tests_properties(${out}
+    PROPERTIES
+    ENVIRONMENT ${scenario}
+    )
     target_link_libraries(${out} gunit)
     add_custom_command(TARGET ${out} COMMAND ${scenario} ./${out} --gtest_color=yes USES_TERMINAL)
   endfunction()


### PR DESCRIPTION
Added environment variables to test registration.
So when the test is run using CTest it will actually run the tests using the defined scenario.

This will enable the use of CTest without needing to redefine the SCENARIO variable.
Making it possible for test explorers to run the test