### PR TITLE
:sparkles: enable support for logical expressions in EXPECT and ASSERT

### DIFF
--- a/include/GUnit/GAssert.h
+++ b/include/GUnit/GAssert.h
@@ -213,7 +213,7 @@ void prevent_commas(T&&) {}
   (::testing::detail::op<std::true_type>{                                    \
        ::testing::detail::info{__FILE__, __LINE__, #__VA_ARGS__,             \
                                ::testing::TestPartResult::kNonFatalFailure}} \
-   << __VA_ARGS__)
+   << (__VA_ARGS__))
 
 #define EXPECT(...)                  \
   GUNIT_PREVENT_COMMAS(__VA_ARGS__); \
@@ -223,14 +223,14 @@ void prevent_commas(T&&) {}
   if (::testing::detail::op<std::false_type>{                                \
           ::testing::detail::info{__FILE__, __LINE__, #__VA_ARGS__,          \
                                   ::testing::TestPartResult::kFatalFailure}} \
-      << __VA_ARGS__)                                                        \
+      << (__VA_ARGS__))                                                      \
     void(::testing::detail::drop{});                                         \
   else                                                                       \
     return ::testing::detail::ret_void{} ==                                  \
            (::testing::detail::op<std::true_type>{::testing::detail::info{   \
                 __FILE__, __LINE__, #__VA_ARGS__,                            \
                 ::testing::TestPartResult::kFatalFailure}}                   \
-            << __VA_ARGS__)
+            << (__VA_ARGS__))
 
 #define ASSERT(...)                  \
   GUNIT_PREVENT_COMMAS(__VA_ARGS__); \

--- a/test/GAssert.cpp
+++ b/test/GAssert.cpp
@@ -37,6 +37,8 @@ TEST(GAssert, ShouldSupportExpect) {
 
   EXPECT(not convertible{});
   EXPECT(false == convertible{});
+
+  EXPECT(false or true);
 }
 
 TEST(GAssert, ShouldSupportASSERT) {
@@ -69,4 +71,6 @@ TEST(GAssert, ShouldSupportASSERT) {
 
   ASSERT(convertible{});
   ASSERT(false == not convertible{});
+
+  ASSERT(false or true);
 }


### PR DESCRIPTION
Problem:
- logical expressions fail in `EXPECT()` and `ASSERT()` because of operator precedence

Solution:
- wrap `__VA_ARGS__` use in macros with an extra set of parens