### PR TITLE
CI: Fix Windows and macOS workflows to use correct runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [macos-latest, macos-13]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
By default, the macOS and Windows GitHub workflows all use the `ubuntu-latest` runner, meaning that all of the tests run on an Ubuntu environment, not Windows or macOS. These changes fix that such that the right runners are chosen to run the tests on the right operating systems.

There are [failures caught on macOS and Windows](https://github.com/divark/GUnit/actions) from the library itself in doing this. I recommend making separate PRs to address these issues.