### PR TITLE
:bug: Fix printing variables when expect or assert fails

### DIFF
--- a/test/GAssert.cpp
+++ b/test/GAssert.cpp
@@ -8,6 +8,20 @@
 #include <gtest/gtest.h>
 #include "GUnit/GAssert.h"
 
+struct call_only_once {
+  int a{42};
+  bool called{false};
+
+  auto value() -> int {
+    if (called) {
+      throw std::runtime_error("Called twice, should only evaluate once.");
+    }
+
+    called = true;
+    return a;
+  }
+};
+
 TEST(GAssert, ShouldSupportExpect) {
   auto i = 42;
   const auto b = true;
@@ -15,6 +29,10 @@ TEST(GAssert, ShouldSupportExpect) {
   EXPECT(true);
   EXPECT(!false) << "message";
   EXPECT(b);
+
+  call_only_once once{};
+  EXPECT(once.value() == 42);
+  EXPECT_THROW(once.value(), std::runtime_error);
 
   EXPECT(i == 42);
   EXPECT(42 == i);


### PR DESCRIPTION
Problem:
- EXPECT and ASSERT macros only print whether the expression is true or false when the test expectations fail
- GUnit stopped printing out the values of the variables used in the expressiong passed to the EXPECT or ASSERT macros
- Fix for logical expression broke variable printing

Solution:
- Remove extra parenthesis in macros that resulted in full evaluation of the expression before the op and cmp objects could be initialized.
- Add CmpHelperAnd/Or/Xor with corresponding and/or/xor overloads to allow evaluating logical expressions.
- Added test to verify tested expressions are only evaluated once.